### PR TITLE
dec2x fixes

### DIFF
--- a/src/sane.cpp
+++ b/src/sane.cpp
@@ -322,17 +322,11 @@ namespace SANE {
 		}
 
 
-		long double tmp = 0;
-		try {
-			size_t pos;
-			std::string str = d.sig + "e" + std::to_string(d.exp);
-			tmp = std::stold(str, &pos);
-			if (pos != str.length()) throw std::invalid_argument("");
-
-		} catch(std::out_of_range &e) {
-			tmp = INFINITY;
-			if (d.exp < 0) tmp = 0;
-		} catch(std::invalid_argument &e) {
+		std::string str = d.sig + "e" + std::to_string(d.exp);
+		const char *cstr = str.c_str();
+		char *end;
+		long double tmp = std::strtold(cstr, &end);
+		if (end-cstr != str.length()) {
 			tmp = make_nan<long double>(NANASCBIN);
 		}
 

--- a/src/sane.cpp
+++ b/src/sane.cpp
@@ -325,20 +325,9 @@ namespace SANE {
 		long double tmp = 0;
 		try {
 			size_t pos;
-			tmp = std::stold(d.sig, &pos);
-			if (pos != d.sig.length()) throw std::invalid_argument("");
-
-			int exp = d.exp;
-
-			while (exp > 0) {
-				tmp = tmp * 10.0;
-				exp--;
-			}
-
-			while (exp < 0) {
-				tmp = tmp / 10.0;
-				exp++;
-			}
+			std::string str = d.sig + "e" + std::to_string(d.exp);
+			tmp = std::stold(str, &pos);
+			if (pos != str.length()) throw std::invalid_argument("");
 
 		} catch(std::out_of_range &e) {
 			tmp = INFINITY;


### PR DESCRIPTION
These changes fix a couple issues in `dec2x` that could cause it to return inaccurate values.

The first is that its approach of doing exponentiation by repeated multiplication/division could introduce small round-off errors in every step, potentially yielding slightly incorrect results, especially for numbers with large exponents.

The second is that subnormal values could be forced to zero. This seems to be an inherent issue with `stold` (at least on some platforms), so I switched to directly calling `strtold` instead. Note that there are other parts of libsane that do not handle subnormals, so full computations involving them still may not work properly.