### PR TITLE
Upgrade CI to checkout@v6 and fix CMakeLists.txt for CMake 4

### DIFF
--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         submodules: true
 

--- a/.github/workflows/cmake-ubuntu.yml
+++ b/.github/workflows/cmake-ubuntu.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         submodules: true
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-set (PROJECT_NAME "libsane")
-set (PROJECT_TYPE "CXX")
+project(libsane LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 set (PROJECT_NAME "libsane")
 set (PROJECT_TYPE "CXX")
 


### PR DESCRIPTION
This PR contains a few commits that are not directly related to one another except that they serve to make this project build successfully in CI again. I've described each change with its own commit message so I recommend not squashing the commits when merging. If you would prefer an individual PR for each commit let me know.

-----

The workflows are updated to use the latest version of actions/checkout because the older version that was being used is deprecated.

-----

The workflows failed with this message:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
-- Detecting C compile features
  Compatibility with CMake < 3.5 has been removed from CMake.
-- Detecting C compile features - done

-- Configuring incomplete, errors occurred!
  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

To fix this, the minimum CMake version is increased from 3.1 to 3.5. If you are using any CMake features whose behaviors have changed between CMake 3.1 and 3.5, other parts of the CMakeLists.txt may need corresponding adjustment. I have not attempted to determine if this is needed.

In fact, CMake is already issuing this warning:

```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```

We could increase the minimum to 3.10 to remove this warning, but again if you are using any CMake features that changed by 3.10, other changes may be needed.

-----

This warning appeared:

```
CMake Warning (dev) in CMakeLists.txt:
  No project() command is present.  The top-level CMakeLists.txt file must
  contain a literal, direct call to the project() command.  Add a line of
  code such as

    project(ProjectName)

  near the top of the file, but after cmake_minimum_required().

  CMake is pretending there is a "project(Project)" command on the first
  line.
```

To fix this, I added the `project()` line, replacing manually setting `PROJECT_NAME` and `PROJECT_TYPE` with `set()`.

-----

Merging this PR is a prerequisite for making corresponding changes in mpw.

-----

I have more changes to suggest in another PR after this one is merged.